### PR TITLE
Remove doi.org URLs

### DIFF
--- a/inst/references.bib
+++ b/inst/references.bib
@@ -18,8 +18,7 @@
   volume       = 19,
   number       = 15,
   pages        = {1997--2014},
-  doi          = {10.1002/1097-0258(20000815)19:15<1997::aid-sim511>3.0.co;2-c},
-  url          = {https://doi.org/10.1002/1097-0258(20000815)19:15<1997::aid-sim511>3.0.co;2-c}
+  doi          = {10.1002/1097-0258(20000815)19:15<1997::aid-sim511>3.0.co;2-c}
 }
 @book{breiman_1984,
   title        = {Classification And Regression Trees},
@@ -39,7 +38,6 @@
   doi          = {10.1023/A:1010933404324},
   issn         = {1573-0565}
 }
-% https://flamingtempura.github.io/bibtex-tidy/
 @article{buehlmann_2003,
   title        = {Boosting With the L2 Loss},
   author       = {Peter B\"{u}hlmann and Bin Yu},
@@ -50,8 +48,7 @@
   volume       = 98,
   number       = 462,
   pages        = {324--339},
-  doi          = {10.1198/016214503000125},
-  url          = {https://doi.org/10.1198/016214503000125}
+  doi          = {10.1198/016214503000125}
 }
 @article{buehlmann_2006,
   title        = {Boosting for High-Dimensional Linear Models},
@@ -74,8 +71,7 @@
   volume       = 22,
   number       = 4,
   pages        = {477--505},
-  doi          = {10.1214/07-sts242},
-  url          = {https://doi.org/10.1214/07-sts242}
+  doi          = {10.1214/07-sts242}
 }
 @techreport{burges_2010,
   title        = {From RankNet to LambdaRank to LambdaMART: An Overview},
@@ -95,8 +91,7 @@
   volume       = 25,
   number       = 20,
   pages        = {3474--3486},
-  doi          = {10.1002/sim.2299},
-  url          = {https://doi.org/10.1002/sim.2299}
+  doi          = {10.1002/sim.2299}
 }
 @article{cox_1972,
   title        = {Regression Models and Life-Tables},
@@ -108,8 +103,7 @@
   volume       = 34,
   number       = 2,
   pages        = {187--202},
-  doi          = {10.1111/j.2517-6161.1972.tb00899.x},
-  url          = {https://doi.org/10.1111/j.2517-6161.1972.tb00899.x}
+  doi          = {10.1111/j.2517-6161.1972.tb00899.x}
 }
 @inproceedings{freund_1996,
   title        = {Experiments with a new boosting algorithm},
@@ -130,8 +124,7 @@
   volume       = 55,
   number       = 1,
   pages        = {119--139},
-  doi          = {10.1006/jcss.1997.1504},
-  url          = {https://doi.org/10.1006/jcss.1997.1504}
+  doi          = {10.1006/jcss.1997.1504}
 }
 @article{friedman_2000,
   title        = {Additive logistic regression: a statistical view of boosting (With discussion and a rejoinder by the authors)},
@@ -143,8 +136,7 @@
   volume       = 28,
   number       = 2,
   pages        = {337--407},
-  doi          = {10.1214/aos/1016218223},
-  url          = {https://doi.org/10.1214/aos/1016218223}
+  doi          = {10.1214/aos/1016218223}
 }
 @article{friedman_2001,
   title        = {Greedy Function Approximation: A Gradient Boosting Machine},
@@ -167,8 +159,7 @@
   volume       = 38,
   number       = 4,
   pages        = {367--378},
-  doi          = {10.1016/s0167-9473(01)00065-2},
-  url          = {https://doi.org/10.1016/s0167-9473(01)00065-2}
+  doi          = {10.1016/s0167-9473(01)00065-2}
 }
 @article{friedman_2010,
   title        = {Regularization Paths for Generalized Linear Models via Coordinate Descent},
@@ -178,8 +169,7 @@
   publisher    = {Foundation for Open Access Statistic},
   volume       = 33,
   number       = 1,
-  doi          = {10.18637/jss.v033.i01},
-  url          = {https://doi.org/10.18637/jss.v033.i01}
+  doi          = {10.18637/jss.v033.i01}
 }
 @article{goeman_2009,
   title        = {L1Penalized Estimation in the Cox Proportional Hazards Model},
@@ -189,8 +179,7 @@
   journal      = {Biometrical Journal},
   publisher    = {Wiley},
   pages        = {NA--NA},
-  doi          = {10.1002/bimj.200900028},
-  url          = {https://doi.org/10.1002/bimj.200900028}
+  doi          = {10.1002/bimj.200900028}
 }
 @article{goenen_2005,
   title        = {Concordance probability and discriminatory power in proportional hazards regression},
@@ -202,8 +191,7 @@
   volume       = 92,
   number       = 4,
   pages        = {965--970},
-  doi          = {10.1093/biomet/92.4.965},
-  url          = {https://doi.org/10.1093/biomet/92.4.965}
+  doi          = {10.1093/biomet/92.4.965}
 }
 @article{graf_1999,
   title        = {Assessment and comparison of prognostic classification schemes for survival data},
@@ -215,8 +203,7 @@
   volume       = 18,
   number       = {17-18},
   pages        = {2529--2545},
-  doi          = {10.1002/(sici)1097-0258(19990915/30)18:17/18<2529::aid-sim274>3.0.co;2-5},
-  url          = {https://doi.org/10.1002/(sici)1097-0258(19990915/30)18:17/18<2529::aid-sim274>3.0.co;2-5}
+  doi          = {10.1002/(sici)1097-0258(19990915/30)18:17/18<2529::aid-sim274>3.0.co;2-5}
 }
 @article{harrell_1982,
   title        = {Evaluating the yield of medical tests},
@@ -238,8 +225,7 @@
   volume       = 29,
   number       = {1-2},
   pages        = {3--35},
-  doi          = {10.1007/s00180-012-0382-5},
-  url          = {https://doi.org/10.1007/s00180-012-0382-5}
+  doi          = {10.1007/s00180-012-0382-5}
 }
 @article{hothorn_2006,
   title        = {Unbiased Recursive Partitioning: A Conditional Inference Framework},
@@ -251,8 +237,7 @@
   volume       = 15,
   number       = 3,
   pages        = {651--674},
-  doi          = {10.1198/106186006x133933},
-  url          = {https://doi.org/10.1198/106186006x133933}
+  doi          = {10.1198/106186006x133933}
 }
 @article{hothorn_2010,
   title        = {Model-based boosting 2.0},
@@ -291,8 +276,7 @@
   year         = 2002,
   month        = aug,
   publisher    = {John Wiley & Sons,  Inc.},
-  doi          = {10.1002/9781118032985},
-  url          = {https://doi.org/10.1002/9781118032985}
+  doi          = {10.1002/9781118032985}
 }
 @article{kaplan_1958,
   title        = {Nonparametric Estimation from Incomplete Observations},
@@ -304,8 +288,7 @@
   volume       = 53,
   number       = 282,
   pages        = {457--481},
-  doi          = {10.1080/01621459.1958.10501452},
-  url          = {https://doi.org/10.1080/01621459.1958.10501452}
+  doi          = {10.1080/01621459.1958.10501452}
 }
 @article{kneib_2008,
   title        = {Variable Selection and Model Choice in Geoadditive Regression Models},
@@ -317,8 +300,7 @@
   volume       = 65,
   number       = 2,
   pages        = {626--634},
-  doi          = {10.1111/j.1541-0420.2008.01112.x},
-  url          = {https://doi.org/10.1111/j.1541-0420.2008.01112.x}
+  doi          = {10.1111/j.1541-0420.2008.01112.x}
 }
 @phdthesis{kriegler_2007,
   title        = {Cost-Sensitive Stochastic Gradient Boosting Within a Quantitative Regression Framework},
@@ -347,8 +329,7 @@
   volume       = 1,
   number       = 1,
   pages        = {27--52},
-  doi          = {10.1080/00224065.1969.11980344},
-  url          = {https://doi.org/10.1080/00224065.1969.11980344}
+  doi          = {10.1080/00224065.1969.11980344}
 }
 @article{nelson_1972,
   title        = {Theory and Applications of Hazard Plotting for Censored Failure Data},
@@ -360,8 +341,7 @@
   volume       = 14,
   number       = 4,
   pages        = {945--966},
-  doi          = {10.1080/00401706.1972.10488991},
-  url          = {https://doi.org/10.1080/00401706.1972.10488991}
+  doi          = {10.1080/00401706.1972.10488991}
 }
 @article{oquigley_2005,
   title        = {Explained randomness in proportional hazards models},
@@ -372,8 +352,7 @@
   volume       = 24,
   number       = 3,
   pages        = {479--489},
-  doi          = {10.1002/sim.1946},
-  url          = {https://doi.org/10.1002/sim.1946}
+  doi          = {10.1002/sim.1946}
 }
 @article{ridgeway_1999,
   title        = {The state of boosting},
@@ -392,8 +371,7 @@
   volume       = 21,
   number       = 15,
   pages        = {2175--2197},
-  doi          = {10.1002/sim.1203},
-  url          = {https://doi.org/10.1002/sim.1203}
+  doi          = {10.1002/sim.1203}
 }
 @article{schmid_2008,
   title        = {Boosting additive models using component-wise P-Splines},
@@ -405,8 +383,7 @@
   volume       = 53,
   number       = 2,
   pages        = {298--311},
-  doi          = {10.1016/j.csda.2008.09.009},
-  url          = {https://doi.org/10.1016/j.csda.2008.09.009}
+  doi          = {10.1016/j.csda.2008.09.009}
 }
 @article{song_2008,
   title        = {A semiparametric approach for the covariate specific ROC curve with survival outcome},
@@ -428,8 +405,7 @@
   volume       = 102,
   number       = 478,
   pages        = {527--537},
-  doi          = {10.1198/016214507000000149},
-  url          = {https://doi.org/10.1198/016214507000000149}
+  doi          = {10.1198/016214507000000149}
 }
 @article{uno_2011,
   title        = {On the C-statistics for evaluating overall adequacy of risk prediction procedures with censored survival data},
@@ -438,8 +414,7 @@
   journal      = {Statistics in Medicine},
   publisher    = {Wiley},
   pages        = {n/a--n/a},
-  doi          = {10.1002/sim.4154},
-  url          = {https://doi.org/10.1002/sim.4154}
+  doi          = {10.1002/sim.4154}
 }
 @article{vanbelle_2010,
   title        = {Improved performance on high-dimensional survival data by application of Survival-{SVM}},
@@ -451,8 +426,7 @@
   volume       = 27,
   number       = 1,
   pages        = {87--94},
-  doi          = {10.1093/bioinformatics/btq617},
-  url          = {https://doi.org/10.1093/bioinformatics/btq617}
+  doi          = {10.1093/bioinformatics/btq617}
 }
 @article{vanbelle_2011,
   title        = {Support vector methods for survival analysis: a comparison between ranking and regression approaches},
@@ -464,8 +438,7 @@
   volume       = 53,
   number       = 2,
   pages        = {107--118},
-  doi          = {10.1016/j.artmed.2011.06.006},
-  url          = {https://doi.org/10.1016/j.artmed.2011.06.006}
+  doi          = {10.1016/j.artmed.2011.06.006}
 }
 @article{wright_2017,
   title        = {{ranger}: A Fast Implementation of Random Forests for High Dimensional Data in {C++} and {R}},
@@ -487,6 +460,5 @@
   volume       = 12,
   number       = 1,
   pages        = {83--107},
-  doi          = {10.1080/10485259908832799},
-  url          = {https://doi.org/10.1080/10485259908832799}
+  doi          = {10.1080/10485259908832799}
 }


### PR DESCRIPTION
They are redundant, the DOI is already correctly displayed and linked.