### PR TITLE
ParamSet for Measure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     checkmate,
     data.table,
     distr6 (>= 1.4.5),
-    mlr3 (>= 0.6.0),
+    mlr3 (>= 0.11.0-9000),
     mlr3misc (>= 0.7.0),
     paradox (>= 0.1.0),
     R6,
@@ -62,6 +62,8 @@ Suggests:
     testthat
 LinkingTo:
     Rcpp
+Remotes:
+    mlr-org/mlr3
 ByteCompile: true
 Encoding: UTF-8
 LazyData: true

--- a/R/MeasureDens.R
+++ b/R/MeasureDens.R
@@ -9,6 +9,7 @@
 #' Predefined measures can be found in the [dictionary][mlr3misc::Dictionary] [mlr3::mlr_measures].
 #'
 #' @template param_id
+#' @template param_param_set
 #' @template param_range
 #' @template param_minimize
 #' @template param_average
@@ -29,13 +30,13 @@ MeasureDens = R6Class("MeasureDens",
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id, range, minimize = NA, aggregator = NULL, properties = character(),
-                          predict_type = "pdf", task_properties = character(),
-                          packages = character(), man = NA_character_) {
+    initialize = function(id, param_set = ps(), range, minimize = NA, aggregator = NULL,
+      properties = character(), predict_type = "pdf", task_properties = character(),
+      packages = character(), man = NA_character_) {
       super$initialize(id,
-        task_type = "dens", range = range, minimize = minimize, aggregator = aggregator,
-        properties = properties, predict_type = predict_type, task_properties = task_properties,
-        packages = packages, man = man)
+        task_type = "dens", param_set = param_set, range = range, minimize = minimize,
+        aggregator = aggregator, properties = properties, predict_type = predict_type,
+        task_properties = task_properties, packages = packages, man = man)
     }
   )
 )

--- a/R/MeasureSurv.R
+++ b/R/MeasureSurv.R
@@ -9,6 +9,7 @@
 #' Predefined measures can be found in the [dictionary][mlr3misc::Dictionary] [mlr3::mlr_measures].
 #'
 #' @template param_id
+#' @template param_param_set
 #' @template param_range
 #' @template param_minimize
 #' @template param_average
@@ -30,13 +31,13 @@ MeasureSurv = R6Class("MeasureSurv",
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id, range, minimize = NA, aggregator = NULL, properties = character(),
-                          predict_type = "distr", task_properties = character(),
-                          packages = character(), man = NA_character_, se = FALSE) {
+    initialize = function(id, param_set = ps(), range, minimize = NA, aggregator = NULL,
+      properties = character(), predict_type = "distr", task_properties = character(),
+      packages = character(), man = NA_character_, se = FALSE) {
       super$initialize(id,
-        task_type = "surv", range = range, minimize = minimize, aggregator = aggregator,
-        properties = properties, predict_type = predict_type, task_properties = task_properties,
-        packages = packages, man = man)
+        task_type = "surv", param_set = param_set, range = range, minimize = minimize,
+        aggregator = aggregator, properties = properties, predict_type = predict_type,
+        task_properties = task_properties, packages = packages, man = man)
     },
 
     #' @description


### PR DESCRIPTION
Measures now can have hyperparameters (https://github.com/mlr-org/mlr3/pull/623). I've used slots before, but this does not work well with hashing and is not really consistent with other classes. 

Most of the measures in mlr3proba seem to have something like hyperparameters which should be transitioned in the long run. If all docs already use sugar functions, this should be quite easy. If you want to keep slots for now, you can also list them under `private$.extra_hash` to ensure that their values get hashed properly.