### PR TITLE
Depend on mlr3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,12 +34,12 @@ URL: https://mlr3proba.mlr-org.com,
     https://github.com/mlr-org/mlr3proba
 BugReports: https://github.com/mlr-org/mlr3proba/issues
 Depends:
+    mlr3 (>= 0.11.0-9000),
     R (>= 3.5.0)
 Imports:
     checkmate,
     data.table,
     distr6 (>= 1.4.5),
-    mlr3 (>= 0.11.0-9000),
     mlr3misc (>= 0.7.0),
     paradox (>= 0.1.0),
     R6,

--- a/R/PredictionDataDens.R
+++ b/R/PredictionDataDens.R
@@ -1,5 +1,5 @@
 #' @export
-as_prediction.PredictionDataDens = function(x, check = TRUE) { # nolint
+as_prediction.PredictionDataDens = function(x, check = TRUE, ...) { # nolint
   invoke(PredictionDens$new, check = check, .args = x)
 }
 

--- a/R/PredictionDataSurv.R
+++ b/R/PredictionDataSurv.R
@@ -1,5 +1,5 @@
 #' @export
-as_prediction.PredictionDataSurv = function(x, check = TRUE) { # nolint
+as_prediction.PredictionDataSurv = function(x, check = TRUE, ...) { # nolint
   invoke(PredictionSurv$new, check = check, .args = x)
 }
 


### PR DESCRIPTION
We have decided to change our policy here a bit. If an extension package is not conveniently usable without mlr3, mlr3 should go into depends instead of imports to simplify the usage.