### PR TITLE
Fix C stack issue in PipeOp test

### DIFF
--- a/tests/testthat/test_pipeop_distrcompositor.R
+++ b/tests/testthat/test_pipeop_distrcompositor.R
@@ -8,8 +8,8 @@ test_that("PipeOpDistrCompositor - overwrite = FALSE", {
   gr = mlr3pipelines::ppl("distrcompositor", lrn("surv.kaplan", id = "k2"), overwrite = FALSE)
   expect_silent(gr$train(task))
   expect_equal(
-    gr$predict(task)[[1]]$distr,
-    lrn("surv.kaplan", id = "k2")$train(task)$predict(task)$distr)
+    gr$predict(task)[[1]]$data$distr,
+    lrn("surv.kaplan", id = "k2")$train(task)$predict(task)$data$distr)
 })
 
 test_that("PipeOpDistrCompositor - overwrite = TRUE", {


### PR DESCRIPTION
Switches from `$distr` to `$data$distr` in expressions used in `expect_equal()` call.

After this modifications the tests pass as expected.