### PR TITLE
Add mlr3proba to required packages

### DIFF
--- a/R/LearnerDens.R
+++ b/R/LearnerDens.R
@@ -41,7 +41,7 @@ LearnerDens = R6::R6Class("LearnerDens",
       super$initialize(
         id = id, task_type = "dens", param_set = param_set,
         predict_types = predict_types, feature_types = feature_types, properties = properties,
-        data_formats = data_formats, packages = packages, man = man)
+        data_formats = data_formats, packages = c("mlr3proba", packages), man = man)
     }
   )
 )

--- a/R/LearnerSurv.R
+++ b/R/LearnerSurv.R
@@ -41,7 +41,8 @@ LearnerSurv = R6Class("LearnerSurv",
       packages = character(), man = NA_character_) {
       super$initialize(
         id = id, task_type = "surv", param_set = param_set, predict_types = predict_types,
-        feature_types = feature_types, properties = properties, packages = packages, man = man)
+        feature_types = feature_types, properties = properties,
+        packages = c("mlr3proba", packages), man = man)
     }
   )
 )

--- a/R/MeasureDens.R
+++ b/R/MeasureDens.R
@@ -36,7 +36,7 @@ MeasureDens = R6Class("MeasureDens",
       super$initialize(id,
         task_type = "dens", param_set = param_set, range = range, minimize = minimize,
         aggregator = aggregator, properties = properties, predict_type = predict_type,
-        task_properties = task_properties, packages = packages, man = man)
+        task_properties = task_properties, packages = c("mlr3proba", packages), man = man)
     }
   )
 )

--- a/R/MeasureSurv.R
+++ b/R/MeasureSurv.R
@@ -37,7 +37,7 @@ MeasureSurv = R6Class("MeasureSurv",
       super$initialize(id,
         task_type = "surv", param_set = param_set, range = range, minimize = minimize,
         aggregator = aggregator, properties = properties, predict_type = predict_type,
-        task_properties = task_properties, packages = packages, man = man)
+        task_properties = task_properties, packages = c("mlr3proba", packages), man = man)
     },
 
     #' @description

--- a/R/PipeOpCrankCompositor.R
+++ b/R/PipeOpCrankCompositor.R
@@ -91,7 +91,7 @@ PipeOpCrankCompositor = R6Class("PipeOpCrankCompositor",
         param_vals = param_vals,
         input = data.table(name = "input", train = "NULL", predict = "PredictionSurv"),
         output = data.table(name = "output", train = "NULL", predict = "PredictionSurv"),
-        packages = "distr6"
+        packages = c("mlr3proba", "distr6")
       )
     }
   ),

--- a/R/PipeOpDistrCompositor.R
+++ b/R/PipeOpDistrCompositor.R
@@ -90,7 +90,7 @@ PipeOpDistrCompositor = R6Class("PipeOpDistrCompositor",
         param_vals = param_vals,
         input = data.table(name = c("base", "pred"), train = "NULL", predict = "PredictionSurv"),
         output = data.table(name = "output", train = "NULL", predict = "PredictionSurv"),
-        packages = "distr6"
+        packages = c("mlr3proba", "distr6")
       )
     }
   ),

--- a/R/PipeOpPredTransformer.R
+++ b/R/PipeOpPredTransformer.R
@@ -39,7 +39,7 @@ PipeOpPredTransformer = R6Class("PipeOpPredTransformer",
       super$initialize(id = id,
         param_set = param_set,
         param_vals = param_vals,
-        packages = packages,
+        packages = c("mlr3proba", packages),
         input = input,
         output = output
       )

--- a/R/PipeOpProbregrCompositor.R
+++ b/R/PipeOpProbregrCompositor.R
@@ -81,7 +81,7 @@ PipeOpProbregrCompositor = R6Class("PipeOpProbregrCompositor",
         input = data.table(name = c("input_response", "input_se"), train = "NULL",
           predict = c("PredictionRegr", "PredictionRegr")),
         output = data.table(name = "output", train = "NULL", predict = "PredictionRegr"),
-        packages = "distr6"
+        packages = c("mlr3proba", "distr6")
       )
     }
   ),

--- a/R/PipeOpSurvAvg.R
+++ b/R/PipeOpSurvAvg.R
@@ -65,6 +65,7 @@ PipeOpSurvAvg = R6Class("PipeOpSurvAvg",
         id = id,
         param_vals = param_vals,
         prediction_type = "PredictionSurv",
+        packages = "mlr3proba",
         ...)
     }
   ),

--- a/R/PipeOpTransformer.R
+++ b/R/PipeOpTransformer.R
@@ -31,8 +31,8 @@ PipeOpTransformer = R6Class("PipeOpTransformer",
       packages = character(), input = data.table(),
       output = data.table()) {
 
-      super$initialize(id = id, param_set = param_set, param_vals = param_vals, packages = packages,
-        input = input, output = output)
+      super$initialize(id = id, param_set = param_set, param_vals = param_vals,
+        packages = c("mlr3proba", packages), input = input, output = output)
     }
   ),
 


### PR DESCRIPTION
Loaded objects from mlr3proba do not work without `mlr3proba` being installed due to the `leanify()` function. Usually not an issue, but we rather list all required packages to ensure a helpful error message on remote machines.