### PR TITLE
feat: add task$kaplan()

### DIFF
--- a/R/TaskSurv.R
+++ b/R/TaskSurv.R
@@ -33,7 +33,7 @@
 #' task$unique_times()
 #' task$unique_event_times()
 #' task$risk_set(time = 700)
-#' task$survfit("sex")
+#' task$kaplan("sex")
 TaskSurv = R6::R6Class("TaskSurv",
   inherit = TaskSupervised,
   public = list(
@@ -194,7 +194,7 @@ TaskSurv = R6::R6Class("TaskSurv",
     },
 
     #' @description
-    #' Creates a [survival::survfit()] object.
+    #' Calls [survival::survfit()] to calculate the Kaplan-Meier estimator.
     #'
     #' @param strata (`character()`)\cr
     #'   Stratification variables to use.
@@ -202,8 +202,8 @@ TaskSurv = R6::R6Class("TaskSurv",
     #'   Subset of row indices.
     #' @param ... (any)\cr
     #'   Additional arguments passed down to [survival::survfit.formula()].
-    #' @return `survival::survfit()` object.
-    survfit = function(strata = NULL, rows = NULL, ...) {
+    #' @return [survival::survfit.object].
+    kaplan = function(strata = NULL, rows = NULL, ...) {
       assert_character(strata, null.ok = TRUE)
       f = self$formula(strata %??% 1)
       cols = c(self$target_names, intersect(self$backend$colnames, strata))

--- a/R/TaskSurv.R
+++ b/R/TaskSurv.R
@@ -33,6 +33,7 @@
 #' task$unique_times()
 #' task$unique_event_times()
 #' task$risk_set(time = 700)
+#' task$survfit("sex")
 TaskSurv = R6::R6Class("TaskSurv",
   inherit = TaskSupervised,
   public = list(
@@ -190,6 +191,26 @@ TaskSurv = R6::R6Class("TaskSurv",
       } else {
         self$row_ids[self$times() >= time]
       }
+    },
+
+    #' @description
+    #' Creates a [survival::survfit()] object.
+    #'
+    #' @param strata (`character()`)\cr
+    #'   Stratification variables to use.
+    #' @param rows (`integer()`)\cr
+    #'   Subset of row indices.
+    #' @param ... (any)\cr
+    #'   Additional arguments passed down to [survival::survfit.formula()].
+    #' @return `survival::survfit()` object.
+    survfit = function(strata = NULL, rows = NULL, ...) {
+      assert_character(strata, null.ok = TRUE)
+      f = self$formula(strata %??% 1)
+      tn = self$target_names
+
+      cols = c(tn, intersect(self$backend$colnames, strata))
+      data = self$data(cols = cols, rows = rows)
+      survival::survfit(f, data = data, ...)
     }
   ),
 

--- a/R/TaskSurv.R
+++ b/R/TaskSurv.R
@@ -206,9 +206,7 @@ TaskSurv = R6::R6Class("TaskSurv",
     survfit = function(strata = NULL, rows = NULL, ...) {
       assert_character(strata, null.ok = TRUE)
       f = self$formula(strata %??% 1)
-      tn = self$target_names
-
-      cols = c(tn, intersect(self$backend$colnames, strata))
+      cols = c(self$target_names, intersect(self$backend$colnames, strata))
       data = self$data(cols = cols, rows = rows)
       survival::survfit(f, data = data, ...)
     }

--- a/inst/testthat/helper_expectations.R
+++ b/inst/testthat/helper_expectations.R
@@ -22,7 +22,7 @@ expect_task_surv = function(task) {
   f = task$formula()
   expect_formula(f)
   expect_set_equal(mlr3misc::extract_vars(f)$lhs, task$target_names)
-  #  expect_is(task$survfit(), "survfit")
+  expect_is(task$survfit(), "survfit")
 }
 
 expect_prediction_surv = function(p) {

--- a/inst/testthat/helper_expectations.R
+++ b/inst/testthat/helper_expectations.R
@@ -22,7 +22,7 @@ expect_task_surv = function(task) {
   f = task$formula()
   expect_formula(f)
   expect_set_equal(mlr3misc::extract_vars(f)$lhs, task$target_names)
-  expect_is(task$survfit(), "survfit")
+  expect_is(task$kaplan(), "survfit")
 }
 
 expect_prediction_surv = function(p) {

--- a/man/TaskSurv.Rd
+++ b/man/TaskSurv.Rd
@@ -30,7 +30,7 @@ task$status()
 task$unique_times()
 task$unique_event_times()
 task$risk_set(time = 700)
-task$survfit("sex")
+task$kaplan("sex")
 }
 \seealso{
 Other Task: 
@@ -59,7 +59,7 @@ Returns the type of censoring, one of "right", "left", "counting", "interval", o
 \item \href{#method-unique_times}{\code{TaskSurv$unique_times()}}
 \item \href{#method-unique_event_times}{\code{TaskSurv$unique_event_times()}}
 \item \href{#method-risk_set}{\code{TaskSurv$risk_set()}}
-\item \href{#method-survfit}{\code{TaskSurv$survfit()}}
+\item \href{#method-kaplan}{\code{TaskSurv$kaplan()}}
 \item \href{#method-clone}{\code{TaskSurv$clone()}}
 }
 }
@@ -284,12 +284,12 @@ Returns the \code{row_ids} of the observations 'at risk' (not dead or censored) 
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-survfit"></a>}}
-\if{latex}{\out{\hypertarget{method-survfit}{}}}
-\subsection{Method \code{survfit()}}{
-Creates a \code{\link[survival:survfit]{survival::survfit()}} object.
+\if{html}{\out{<a id="method-kaplan"></a>}}
+\if{latex}{\out{\hypertarget{method-kaplan}{}}}
+\subsection{Method \code{kaplan()}}{
+Calls \code{\link[survival:survfit]{survival::survfit()}} to calculate the Kaplan-Meier estimator.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TaskSurv$survfit(strata = NULL, rows = NULL, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TaskSurv$kaplan(strata = NULL, rows = NULL, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -307,7 +307,7 @@ Additional arguments passed down to \code{\link[survival:survfit.formula]{surviv
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\code{survival::survfit()} object.
+\link[survival:survfit.object]{survival::survfit.object}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/TaskSurv.Rd
+++ b/man/TaskSurv.Rd
@@ -30,6 +30,7 @@ task$status()
 task$unique_times()
 task$unique_event_times()
 task$risk_set(time = 700)
+task$survfit("sex")
 }
 \seealso{
 Other Task: 
@@ -58,6 +59,7 @@ Returns the type of censoring, one of "right", "left", "counting", "interval", o
 \item \href{#method-unique_times}{\code{TaskSurv$unique_times()}}
 \item \href{#method-unique_event_times}{\code{TaskSurv$unique_event_times()}}
 \item \href{#method-risk_set}{\code{TaskSurv$risk_set()}}
+\item \href{#method-survfit}{\code{TaskSurv$survfit()}}
 \item \href{#method-clone}{\code{TaskSurv$clone()}}
 }
 }
@@ -279,6 +281,33 @@ Returns the \code{row_ids} of the observations 'at risk' (not dead or censored) 
 }
 \subsection{Returns}{
 \code{integer()}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-survfit"></a>}}
+\if{latex}{\out{\hypertarget{method-survfit}{}}}
+\subsection{Method \code{survfit()}}{
+Creates a \code{\link[survival:survfit]{survival::survfit()}} object.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TaskSurv$survfit(strata = NULL, rows = NULL, ...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{strata}}{(\code{character()})\cr
+Stratification variables to use.}
+
+\item{\code{rows}}{(\code{integer()})\cr
+Subset of row indices.}
+
+\item{\code{...}}{(any)\cr
+Additional arguments passed down to \code{\link[survival:survfit.formula]{survival::survfit.formula()}}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+\code{survival::survfit()} object.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/mlr3proba-package.Rd
+++ b/man/mlr3proba-package.Rd
@@ -8,10 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-Provides extensions for probabilistic supervised learning for
-    'mlr3'.  This includes extending the regression task to probabilistic
-    and interval regression, adding a survival task, and other specialized
-    models, predictions, and measures.
+Provides extensions for probabilistic supervised learning for 'mlr3'. This includes extending the regression task to probabilistic and interval regression, adding a survival task, and other specialized models, predictions, and measures.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test_TaskSurv.R
+++ b/tests/testthat/test_TaskSurv.R
@@ -60,6 +60,8 @@ test_that("surv methods", {
   expect_equal(task$unique_times(), c(1, 2, 4))
   expect_equal(task$unique_event_times(), c(1, 2))
   expect_equal(task$risk_set(2), c(3L, 4L, 5L))
+  expect_is(task$survfit(), "survfit")
+  expect_is(task$survfit(rows = 1:3), "survfit")
 })
 
 

--- a/tests/testthat/test_TaskSurv.R
+++ b/tests/testthat/test_TaskSurv.R
@@ -60,8 +60,8 @@ test_that("surv methods", {
   expect_equal(task$unique_times(), c(1, 2, 4))
   expect_equal(task$unique_event_times(), c(1, 2))
   expect_equal(task$risk_set(2), c(3L, 4L, 5L))
-  expect_is(task$survfit(), "survfit")
-  expect_is(task$survfit(rows = 1:3), "survfit")
+  expect_is(task$kaplan(), "survfit")
+  expect_is(task$kaplan(rows = 1:3), "survfit")
 })
 
 

--- a/tests/testthat/test_mlr_measures.R
+++ b/tests/testthat/test_mlr_measures.R
@@ -100,7 +100,7 @@ test_that("t_max, p_max", {
   m2 = p$score(msr("surv.graf", t_max = 100))
   expect_equal(m1, m2)
 
-  s = survival::survfit(t$formula(1), data = t$data())
+  s = t$survfit()
 
   t_max = s$time[which(1 - s$n.risk / s$n > 0.3)[1]]
 

--- a/tests/testthat/test_mlr_measures.R
+++ b/tests/testthat/test_mlr_measures.R
@@ -100,7 +100,7 @@ test_that("t_max, p_max", {
   m2 = p$score(msr("surv.graf", t_max = 100))
   expect_equal(m1, m2)
 
-  s = t$survfit()
+  s = t$kaplan()
 
   t_max = s$time[which(1 - s$n.risk / s$n > 0.3)[1]]
 


### PR DESCRIPTION
I've seen 6f9b90d8f4ab5d34f3c70252dac5178bf9368cb1, but I still believe that `survfit` is an important object to ensure interoperability with other third party packages, e.g. survminer. This PR re-introduces the `survfit()` method which was previously removed.