### PR TITLE
fix: pipeop's initial values are set during initialize

### DIFF
--- a/R/PipeOpCrankCompositor.R
+++ b/R/PipeOpCrankCompositor.R
@@ -77,8 +77,7 @@ delayedAssign(
     public = list(
       #' @description
       #' Creates a new instance of this [R6][R6::R6Class] class.
-      initialize = function(id = "compose_crank", param_vals = list(
-        method = "sum_haz", response = FALSE, overwrite = FALSE)) {
+      initialize = function(id = "compose_crank", param_vals = list()) {
         ps = ps(
           method = p_fct(default = "sum_haz", levels = c("sum_haz", "mean", "median", "mode"),
             tags = "predict"),
@@ -87,6 +86,7 @@ delayedAssign(
           overwrite = p_lgl(default = FALSE, tags = "predict")
         )
         ps$add_dep("which", "method", CondEqual$new("mode"))
+        ps$values = list(method = "sum_haz", response = FALSE, overwrite = FALSE) 
 
         super$initialize(
           id = id,

--- a/R/PipeOpDistrCompositor.R
+++ b/R/PipeOpDistrCompositor.R
@@ -82,14 +82,16 @@ delayedAssign(
     public = list(
       #' @description
       #' Creates a new instance of this [R6][R6::R6Class] class.
-      initialize = function(id = "compose_distr", param_vals = list(form = "aft", overwrite = FALSE)) {
+      initialize = function(id = "compose_distr", param_vals = list()) {
+        param_set = ps(
+          form = p_fct(default = "aft", levels = c("aft", "ph", "po"), tags = c("predict")),
+          overwrite = p_lgl(default = FALSE, tags = c("predict"))
+        )
+        param_set$values = list(form = "aft", overwrite = FALSE)
         super$initialize(
           id = id,
-          param_set = ps(
-            form = p_fct(default = "aft", levels = c("aft", "ph", "po"), tags = c("predict")),
-            overwrite = p_lgl(default = FALSE, tags = c("predict"))
-          ),
           param_vals = param_vals,
+          param_set = param_set,
           input = data.table(name = c("base", "pred"), train = "NULL", predict = "PredictionSurv"),
           output = data.table(name = "output", train = "NULL", predict = "PredictionSurv"),
           packages = c("mlr3proba", "distr6")

--- a/R/PipeOpProbregrCompositor.R
+++ b/R/PipeOpProbregrCompositor.R
@@ -68,12 +68,13 @@ delayedAssign(
     public = list(
       #' @description
       #' Creates a new instance of this [R6][R6::R6Class] class.
-      initialize = function(id = "compose_probregr", param_vals = list(dist = "Normal")) {
+      initialize = function(id = "compose_probregr", param_vals = list()) {
         ps = ps(
           dist = p_fct(default = "Normal",
             levels = distr6::listDistributions(filter = list(Tags = "locscale"), simplify = TRUE),
             tags = "predict")
         )
+        ps$values = list(dist = "Normal")
 
         super$initialize(
           id = id,

--- a/man/mlr_pipeops_compose_crank.Rd
+++ b/man/mlr_pipeops_compose_crank.Rd
@@ -115,10 +115,7 @@ Other survival compositors:
 \subsection{Method \code{new()}}{
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PipeOpCrankCompositor$new(
-  id = "compose_crank",
-  param_vals = list(method = "sum_haz", response = FALSE, overwrite = FALSE)
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PipeOpCrankCompositor$new(id = "compose_crank", param_vals = list())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/mlr_pipeops_compose_distr.Rd
+++ b/man/mlr_pipeops_compose_distr.Rd
@@ -122,10 +122,7 @@ Other survival compositors:
 \subsection{Method \code{new()}}{
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PipeOpDistrCompositor$new(
-  id = "compose_distr",
-  param_vals = list(form = "aft", overwrite = FALSE)
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PipeOpDistrCompositor$new(id = "compose_distr", param_vals = list())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/mlr_pipeops_compose_probregr.Rd
+++ b/man/mlr_pipeops_compose_probregr.Rd
@@ -101,10 +101,7 @@ if (requireNamespace("mlr3pipelines", quietly = TRUE) &&
 \subsection{Method \code{new()}}{
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PipeOpProbregrCompositor$new(
-  id = "compose_probregr",
-  param_vals = list(dist = "Normal")
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PipeOpProbregrCompositor$new(id = "compose_probregr", param_vals = list())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{


### PR DESCRIPTION
The difference is that PipeOpXYX$new(param_vals = list(a = 1)) used to overwrite ALL initial values.
This was inconsistent with mlr3pipelines, where the above call would have only replaced the initial value of parameter a