### PR TITLE
Fix citation for Lin 2007

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,12 @@ Authors@R:
              family = "Zobolas",
              role = c("cre", "aut"),
              email = "bblodfon@gmail.com",
-             comment = c(ORCID = "0000-0002-3609-8674")))
+             comment = c(ORCID = "0000-0002-3609-8674")),
+      person(given = "Lukas", 
+             family = "Burk",
+             email = "github@quantenbrot.de", 
+             role = "ctb",
+             comment = c(ORCID = "0000-0001-7528-3795")))
 Description: Provides extensions for probabilistic supervised learning for
     'mlr3'.  This includes extending the regression task to probabilistic
     and interval regression, adding a survival task, and other specialized

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -638,7 +638,7 @@ bibentries = c( # nolint start
     number            = "4",
     pages             = "471-480",
     publisher         = "Springer",
-    doi               = "10.1007/S10985-007-9048-Y/METRICS"
+    doi               = "https://doi.org/10.1007/s10985-007-9048-y"
   ),
   avati_2020 = bibentry("article",
     author            = "Avati, Anand and Duan, Tony and Zhou, Sharon and Jung, Kenneth and Shah, Nigam H and Ng, Andrew Y",

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -638,7 +638,7 @@ bibentries = c( # nolint start
     number            = "4",
     pages             = "471-480",
     publisher         = "Springer",
-    doi               = "doi.org/10.1007/s10985-007-9048-y"
+    doi               = "10.1007/s10985-007-9048-y"
   ),
   avati_2020 = bibentry("article",
     author            = "Avati, Anand and Duan, Tony and Zhou, Sharon and Jung, Kenneth and Shah, Nigam H and Ng, Andrew Y",

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -638,7 +638,7 @@ bibentries = c( # nolint start
     number            = "4",
     pages             = "471-480",
     publisher         = "Springer",
-    doi               = "https://doi.org/10.1007/s10985-007-9048-y"
+    doi               = "doi.org/10.1007/s10985-007-9048-y"
   ),
   avati_2020 = bibentry("article",
     author            = "Avati, Anand and Duan, Tony and Zhou, Sharon and Jung, Kenneth and Shah, Nigam H and Ng, Andrew Y",

--- a/man/breslow.Rd
+++ b/man/breslow.Rd
@@ -112,5 +112,5 @@ Cox DR (1972).
 Lin, Y. D (2007).
 \dQuote{On the Breslow estimator.}
 \emph{Lifetime Data Analysis}, \bold{13}(4), 471-480.
-\doi{10.1007/S10985-007-9048-Y/METRICS}.
+\doi{10.1007/s10985-007-9048-y}.
 }

--- a/man/mlr3proba-package.Rd
+++ b/man/mlr3proba-package.Rd
@@ -31,6 +31,7 @@ Other contributors:
 \itemize{
   \item Nurul Ain Toha \email{nurul.toha.15@ucl.ac.uk} [contributor]
   \item Andreas Bender \email{bender.at.R@gmail.com} (\href{https://orcid.org/0000-0001-5628-8611}{ORCID}) [contributor]
+  \item Lukas Burk \email{github@quantenbrot.de} (\href{https://orcid.org/0000-0001-7528-3795}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
The doi had a trailing `/METRICS` which made the link lead to a 404 page.  

I substituted the doi with the one directly copied from the publisher site.