### PR TITLE
`mlr3` update to `0.21.0`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ License: LGPL-3
 URL: https://mlr3proba.mlr-org.com, https://github.com/mlr-org/mlr3proba
 BugReports: https://github.com/mlr-org/mlr3proba/issues
 Depends:
-    mlr3 (>= 0.14.1),
+    mlr3 (>= 0.20.2.9000),
     R (>= 3.5.0)
 Imports:
     checkmate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,8 @@ LinkingTo:
 Remotes:
     xoopR/distr6,
     xoopR/param6,
-    xoopR/set6
+    xoopR/set6,
+    mlr-org/mlr3
 Config/testthat/edition: 3
 ByteCompile: true
 Encoding: UTF-8

--- a/R/TaskSurv.R
+++ b/R/TaskSurv.R
@@ -393,7 +393,7 @@ TaskSurv = R6::R6Class("TaskSurv",
       assert_choice(self$censtype, choices = c("right", "left"))
 
       cox = lrn("surv.coxph")
-      cox$encapsulate = c(train = "evaluate", predict = "evaluate")
+      cox$encapsulate("evaluate", fallback = lrn("surv.kaplan"))
       cox$train(self)
       ok = (length(cox$errors) == 0L) & (length(cox$warnings) == 0L)
 

--- a/R/integrated_scores.R
+++ b/R/integrated_scores.R
@@ -57,7 +57,7 @@ weighted_survival_score = function(loss, truth, distribution, times = NULL,
     } else { # survival 2d array
       surv_mat = distribution
     }
-    surv_mat = surv_mat[, as.numeric(colnames(surv_mat)) <= t_max]
+    surv_mat = surv_mat[, as.numeric(colnames(surv_mat)) <= t_max, drop = FALSE]
     mtc = findInterval(unique_times, as.numeric(colnames(surv_mat)))
     cdf = 1 - surv_mat[, mtc, drop = FALSE]
     if (any(mtc == 0)) {

--- a/tests/testthat/test_mlr_measures.R
+++ b/tests/testthat/test_mlr_measures.R
@@ -130,6 +130,13 @@ test_that("graf proper option", {
   expect_gt(s2, s1)
 })
 
+test_that("graf with 1 time point", {
+  data = data.frame(time = c(1,1), status = c(1,0), f1 = c(5,3))
+  task = as_task_surv(x = data, event = "status", time = "time")
+  res = suppressWarnings(lrn("surv.coxph")$train(task)$predict(task))
+  expect_number(res$score(msr("surv.graf", times = 1)))
+})
+
 test_that("t_max, p_max", {
   set.seed(1L)
   t = tsk("rats")$filter(sample(1:300, 50))


### PR DESCRIPTION
- graf score is fixed in #407, should remove the code related to the graf score from here
- Merge after `mlr3` `0.21.0` gets published on CRAN