### PR TITLE
`ooplah` fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Imports:
 Suggests:
     abind,
     coxed,
+    dictionar6 (<= 0.1.3),
     GGally,
     glmnet,
     gss,
@@ -55,6 +56,7 @@ Suggests:
     logspline,
     mirai,
     mlr3learners (>= 0.10.0),
+    ooplah (>= 0.2.0),
     np,
     pammtools,
     param6 (>= 0.2.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3proba
 Title: Probabilistic Supervised Learning for 'mlr3'
-Version: 0.8.6
+Version: 0.8.7
 Authors@R: c(
     person("Raphael", "Sonabend", , "raphaelsonabend@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0001-9225-4654")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,7 +75,9 @@ Remotes:
     jkropko/coxed@bc92e25,
     xoopR/distr6,
     xoopR/param6,
-    xoopR/set6
+    xoopR/set6,
+    xoopR/dictionar6,
+    xoopR/ooplah
 ByteCompile: true
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,11 +73,11 @@ LinkingTo:
     Rcpp
 Remotes:
     jkropko/coxed@bc92e25,
-    xoopR/distr6,
-    xoopR/param6,
-    xoopR/set6,
+    xoopR/ooplah,
     xoopR/dictionar6,
-    xoopR/ooplah
+    xoopR/set6,
+    xoopR/param6,
+    xoopR/distr6
 ByteCompile: true
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mlr3proba 0.8.7
+
+* Fix `dictionar6` and `ooplah` CRAN removal
+
 # mlr3proba 0.8.6
 
 * Fix compatibility with `mlr3` (1.3.0)


### PR DESCRIPTION
[ooplah](https://cran.r-project.org/web/packages/ooplah/index.html) was removed from CRAN, this probably breaks `distr6`, which breaks `mlr3proba` installation.